### PR TITLE
new ui - questions and potentials

### DIFF
--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -56,22 +56,10 @@
   (let ((album-uri (alist-get '(album uri) track)))
     (spotify-play-href album-uri)))
 
-;; find the artist and the track of a given string. The used separator is :
-;; example of query-string:  :a:Bob Dylan :t: Track
-(setq artist-name "")
-(setq track-name "")
-(defun find-artist-and-track (complete-list)
-  (let ((match-value-list (cons (nth 0 complete-list) (nth 1 complete-list))))
-    (when complete-list
-      (cond ((string= (car match-value-list) "a") (setq artist-name (cdr match-value-list)))
-	    ((string= (car match-value-list) "t") (setq track-name  (cdr match-value-list))))
-      (find-artist-and-track (cdr (cdr complete-list))))))
-
 
 (defun spotify-search (search-term)
   "Search spotify for SEARCH-TERM, returning the results as a Lisp structure."
-  (find-artist-and-track (cdr (split-string search-term ":")))
-  (let ((a-url (format "https://api.spotify.com/v1/search?q=artist:%s&type=track&limit=50" artist-name)))
+  (let ((a-url (format "https://api.spotify.com/v1/search?q=artist:%s&type=track&limit=50" search-term)))
     (with-current-buffer
 	(url-retrieve-synchronously a-url)
       (goto-char url-http-end-of-headers)
@@ -98,8 +86,8 @@
 	  (alist-get '(tracks items) (spotify-search search-term))))
 
 
-(defun helm-spotify-search (search-term)
-  (spotify-search-formatted search-term))
+(defun helm-spotify-search ()
+  (spotify-search-formatted helm-pattern))
 
 (defun helm-spotify-actions-for-track (actions track)
   "Return a list of helm ACTIONS available for this TRACK."
@@ -123,15 +111,6 @@
   (interactive)
   (helm :sources '(helm-source-spotify-track-search)
 	:buffer "*helm-spotify*"))
-
-
-(defun helm-test ()
-  (interactive)
-  (helm :sources (helm-build-sync-source "test"
-		 :candidates (helm-spotify-search ":a:muse")
-		 :fuzzy-match t)
-      :buffer "*helm test*"))
-
 
 (provide 'helm-spotify)
 ;;; helm-spotify.el ends here

--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -6,9 +6,21 @@
 ;;; API Reference: https://developer.spotify.com/technologies/web-api/
 (require 'url)
 (require 'json)
-(require 'helm)
-(require 'multi)
 
+;; installing helm - using use-package!
+(if 'use-package
+    (progn 
+      (use-package helm
+        :ensure t
+        :diminish helm-mode
+        :config
+        (helm-autoresize-mode 1)
+        (setq helm-autoresize-max-height 30)
+        (setq helm-autoresize-min-height 20))
+      (use-package multi
+        :ensure t))
+  (message "You need to install Helm to make use of this module. Future releases will provide it"))
+      
 (defun alist-get (symbols alist)
   "Look up the value for the chain of SYMBOLS in ALIST."
   (if symbols

--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -1,6 +1,4 @@
-;;; helm-spotify.el --- Control Spotify with Helm.
-;; Copyright 2013 Kris Jenkins
-;;
+;;; helm-spotify-plus.el --- Control Spotify with Helm.
 ;;; Code:
 
 ;;; API Reference: https://developer.spotify.com/technologies/web-api/
@@ -134,5 +132,5 @@
 
 
 
-(provide 'helm-spotify)
-;;; helm-spotify.el ends here
+(provide 'helm-spotify-plus)
+;;; helm-spotify-plus.el ends here


### PR DESCRIPTION
When **M-x helm-spotify** is fired, an prompt will ask for a partial or full name of a Track.

After that the list of candidates will be created and we will be able to narrow it using fuzzy matching.

This can be easily extended to accomplish:

1. Partial/full name of Artist search
2. Partial/full name of a Track search
3. Partial/full name of a Album seach
4. The initial idea of identifiers in the string to tell what is the artist, track, album and etc. Ex:  artist: bob dylan track: high
5. I created a Action which fires all the process from the beginning. [f4] Restart Search that would be very useful if you are not satisfied with the current results. [This option is not in this PR yet]

Item 4 is now easy to do because the string is created before helm-candidates. So we can get the portions of the string that matters and feed the API search.

The real question is: Is this UI good enough?