### PR TITLE
Feature / Track Queueing

### DIFF
--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -389,7 +389,7 @@ This is so spotify doesn't start a new song due to mismatch in time.")
   "Return a list of helm ACTIONS available for this TRACK."
   `((,(format "Play Track - %s" (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(name) track)))       . helm-spotify-plus-queue-play-track-wrapper)
     (,(format "Play Album - %s" (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(album name) track))) . helm-spotify-plus-queue-play-album-wrapper)
-    (,(format (if spotify-queue "Queue Track - %s" "Start play-queue with - %s") (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(name) track)))      . helm-spotify-plus-queue-add-track)
+    (,(format "Queue Track - %s" (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(name) track)))      . helm-spotify-plus-queue-add-track)
     ("Show Track Metadata" . pp)))
 
 


### PR DESCRIPTION
Was wondering why there wasn't queueing, then realised there's no support for it in Spotify- DBUS or AppleScript.

### Internal Queue
- Queue managed by `helm-spotify-plus`
- Using track durations and emacs timers
<img width="630" alt="screenshot 2018-12-14 at 05 17 12" src="https://user-images.githubusercontent.com/9072087/49982895-9913fc80-ff5f-11e8-9e1a-8faaea34d5d9.png">

### Wrappers around actions (and modifications)
- `-play-track-wrapper` adds track to start of queue, then skips to next in queue
- `-play-album-wrapper` stops queue-playing, play album like normal
- `helm-spotify-plus-next` if track queued -> skip to it internally, if not -> next in Spotify like normal

#### Exposes var `spotify-queue`
- List of tracks in queue
- Current track is first element in queue

#### defvar `helm-spotify-queue-song-end-soft-limit`
Time in milliseconds for preemptive skip to next queued track.
This is so spotify doesn't start a new song due to mismatch in time.

#### Caveats
- Skimming/skipping in Spotify app, i.e outside of `helm-spotify-plus`, messes up the timing of the queue

It's not a perfect solution to queueing, but I've found it works pretty well.