### PR TITLE
Queueing robustness, and fixes renaming

### DIFF
--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -117,6 +117,7 @@
 (defun helm-spotify-plus-pause ()
   "Pause the current song."
   (interactive)
+  (helm-spotify-plus-stop-queue-playing)
   (cond
    ((eq system-type 'gnu/linux)
     (helm-spotify-plus-action "Pause"))
@@ -130,6 +131,7 @@
 (defun helm-spotify-plus-play ()
   "Play a song."
   (interactive)
+  (helm-spotify-plus-stop-queue-playing)
   (cond
    ((eq system-type 'gnu/linux)
     (helm-spotify-plus-action "Play"))
@@ -143,6 +145,7 @@
 (defun helm-spotify-plus-previous ()
   "Plays previous song."
   (interactive)
+  (helm-spotify-plus-stop-queue-playing)
   (cond
    ((eq system-type 'gnu/linux)
     (helm-spotify-plus-action "Previous"))
@@ -203,6 +206,13 @@ Can be called to skip to next song in queue."
                                  nil
                                  'helm-spotify-plus-queue-track-finished)))))
 
+(defun helm-spotify-plus-stop-queue-playing ()
+  "Stops the `helm-spotify-plus-queue-timer' and empties the `helm-spotify-plus-queue'"
+  (when helm-spotify-plus-queue-timer
+    (cancel-timer helm-spotify-plus-queue-timer)
+    (setq helm-spotify-plus-queue-timer nil))
+  (setq helm-spotify-plus-queue nil))
+
 (defun helm-spotify-plus-queue-add-track (track)
   "Add the TRACK to the queue."
   (if helm-spotify-plus-queue
@@ -223,10 +233,7 @@ Can be called to skip to next song in queue."
 
 (defun helm-spotify-plus-queue-play-album-wrapper (track)
   "Wrapper for `helm-spotify-plus-play-album' to stop queue-playing and play a TRACK."
-  (when helm-spotify-plus-queue-timer
-    (cancel-timer helm-spotify-plus-queue-timer)
-    (setq helm-spotify-plus-queue-timer nil))
-  (setq helm-spotify-plus-queue nil)
+  (helm-spotify-plus-stop-queue-playing)
   (helm-spotify-plus-play-album track))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -102,7 +102,7 @@
 (defun helm-spotify-plus-next ()
   "Play the next song."
   (interactive)
-  (if (equal (length spotify-queue) 2)
+  (if (equal (length helm-spotify-plus-queue) 2)
       (helm-spotify-plus-queue-track-finished)
     (cond
      ((eq system-type 'gnu/linux)

--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -117,7 +117,7 @@
 (defun helm-spotify-plus-pause ()
   "Pause the current song."
   (interactive)
-  (helm-spotify-plus-stop-queue-playing)
+  (helm-spotify-plus-queue-stop)
   (cond
    ((eq system-type 'gnu/linux)
     (helm-spotify-plus-action "Pause"))
@@ -131,7 +131,7 @@
 (defun helm-spotify-plus-play ()
   "Play a song."
   (interactive)
-  (helm-spotify-plus-stop-queue-playing)
+  (helm-spotify-plus-queue-stop)
   (cond
    ((eq system-type 'gnu/linux)
     (helm-spotify-plus-action "Play"))
@@ -145,7 +145,7 @@
 (defun helm-spotify-plus-previous ()
   "Plays previous song."
   (interactive)
-  (helm-spotify-plus-stop-queue-playing)
+  (helm-spotify-plus-queue-stop)
   (cond
    ((eq system-type 'gnu/linux)
     (helm-spotify-plus-action "Previous"))
@@ -190,9 +190,9 @@ This is so spotify doesn't start a new song due to mismatch in time."
   "Called when track finished according to queue timer.
 Can be called to skip to next song in queue."
   (setq helm-spotify-plus-queue (cdr helm-spotify-plus-queue))
-  (helm-spotify-plus-queue-play-next))
+  (helm-spotify-plus-queue-play-queue))
 
-(defun helm-spotify-plus-queue-play-next ()
+(defun helm-spotify-plus-queue-play-queue ()
   "Play next TRACK in the queue."
   (when helm-spotify-plus-queue-timer
     (cancel-timer helm-spotify-plus-queue-timer)
@@ -206,7 +206,7 @@ Can be called to skip to next song in queue."
                                  nil
                                  'helm-spotify-plus-queue-track-finished)))))
 
-(defun helm-spotify-plus-stop-queue-playing ()
+(defun helm-spotify-plus-queue-stop ()
   "Stops the `helm-spotify-plus-queue-timer' and empties the `helm-spotify-plus-queue'"
   (when helm-spotify-plus-queue-timer
     (cancel-timer helm-spotify-plus-queue-timer)
@@ -219,7 +219,7 @@ Can be called to skip to next song in queue."
       (add-to-list 'helm-spotify-plus-queue track t)
     (progn
       (setq helm-spotify-plus-queue (list track))
-      (helm-spotify-plus-queue-play-next))))
+      (helm-spotify-plus-queue-play-queue))))
 
 (defun helm-spotify-plus-queue-play-track-wrapper (track)
   "Wrapper for `helm-spotify-plus-play-track' to correctly go ahead of the queue and play the TRACK."
@@ -229,11 +229,11 @@ Can be called to skip to next song in queue."
         (add-to-list 'helm-spotify-plus-queue track)) ; add the "play now" track to the front of the queue
     (setq helm-spotify-plus-queue (list track)))
 
-  (helm-spotify-plus-queue-play-next))
+  (helm-spotify-plus-queue-play-queue))
 
 (defun helm-spotify-plus-queue-play-album-wrapper (track)
   "Wrapper for `helm-spotify-plus-play-album' to stop queue-playing and play a TRACK."
-  (helm-spotify-plus-stop-queue-playing)
+  (helm-spotify-plus-queue-stop)
   (helm-spotify-plus-play-album track))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -396,7 +396,7 @@ Can be called to skip to next song in queue."
   "Return a list of helm ACTIONS available for this TRACK."
   `((,(format "Play Track - %s" (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(name) track)))       . helm-spotify-plus-queue-play-track-wrapper)
     (,(format "Play Album - %s" (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(album name) track))) . helm-spotify-plus-queue-play-album-wrapper)
-    (,(format "Queue Track - %s" (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(name) track)))      . helm-spotify-plus-queue-add-track)
+    (,(format (if helm-spotify-plus-queue "Queue Track - %s" "Start Queue Playing - %s") (helm-spotify-plus-decode-utf8 (helm-spotify-plus-alist-get '(name) track)))      . helm-spotify-plus-queue-add-track)
     ("Show Track Metadata" . pp)))
 
 


### PR DESCRIPTION
This adds a little consistency to the queue playing mode. And fixes the forgotten renames ;)

#### Notes about the `spotify-controls`
`helm-spotify-plus-previous` stops the queue-playing and empties the queue.
Because, there is no way to get the duration of the track spotify skips back to.
Previous in spotify usually doesn't play previous in queue, so I guess that not doing that with this is OK. But having the queue survive would be nice.

`helm-spotify-plus-toggle-play-pause`, and `pause` and `play` stops the queue-playing and empties the queue.
This is because it isn't possible to pause the queue-timer, AFAIK.

`helm-spotify-plus-next` works great with the queueing. 

#### Notion of a queue-playing "mode"
If nothing is queued the action is described as such:
<img width="584" alt="screenshot 2018-12-14 at 18 12 12" src="https://user-images.githubusercontent.com/9072087/50017226-d01ff780-ffcb-11e8-8288-1f147b3413fd.png">
- But this could be made a lot clearer,
- Maybe some messages that say when queue-playing is stopped, e.g when '-previous', "Play album" etc, is called.

As you can tell, it's hard to get this internal queueing to be as consistent as the helm-spotify-plus package is otherwise. That said, the queueing feature doesn't affect the normal functionality of the package, so if you don't use the queueing feature, the package is as consistent as ever.

All in all it works pretty great, especially for my use case. Which is queueing tracks, and occasionally wanting to skip to next track in the queue.
