### PR TITLE
Wrong keyword on Mac OS X for playing current song.

### DIFF
--- a/helm-spotify-plus.el
+++ b/helm-spotify-plus.el
@@ -95,7 +95,7 @@ Nil values to disable this filter."
 					      test equal
 					      data (
 						    "play-unix" "Play"
-						    "play-darwin" "play track"
+						    "play-darwin" "play"
 						    "next-unix" "Next"
 						    "next-darwin" "next track"
 						    "pause-unix" "Pause"


### PR DESCRIPTION
`play track` is for playing a specific track, making `helm-spotify-plus-play` not work.